### PR TITLE
Fix hex regex by adding "+"

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -1781,7 +1781,7 @@ function isAgent(agent) {
 function isHex(str) {
   return typeof str === 'string'
     && str.length % 2 === 0
-    && /^[0-9a-f]$/i.test(str);
+    && /^[0-9a-f]+$/i.test(str);
 }
 
 function hex32(num) {


### PR DESCRIPTION
This current regex was failing for me, but I was able to fix it with adding "+" before the "$". 